### PR TITLE
📝 doc: fix markdown syntax

### DIFF
--- a/audio_recoder/README.md
+++ b/audio_recoder/README.md
@@ -1,12 +1,12 @@
-#Audio Recorder
+# Audio Recorder
 
-##Library Required
+## Library Required
 - tkinter
 - threading
 - pyaudio
 - wave
 
-##steps to record audio -
+## steps to record audio -
 1. Run the .py file on your python IDE
 2. Dialogue box with 2 options **Start** and **Stop** buttons.
 3. Press **Start** to start the recording.


### PR DESCRIPTION
Markdown preview won't render correctly without space after "#"