### PR TITLE
Fixed the issue of pomodoro timer not running on mac because of winsound

### DIFF
--- a/pomodoro_timer/pomodoro_timer.py
+++ b/pomodoro_timer/pomodoro_timer.py
@@ -78,8 +78,7 @@ def start_timer(options, cycle_limit=5):
             winsound.Beep(323, 250)
             winsound.Beep(583, 250)
         except:
-            os.system('beep -f %s -l %s' % (323,250))
-            os.system('beep -f %s -l %s' % (583,250))
+            os.system('tput bel')
 
         while temp_break:
             title_label.config(text="You should be taking a break now.")
@@ -92,8 +91,7 @@ def start_timer(options, cycle_limit=5):
             winsound.Beep(523, 250)
             winsound.Beep(783, 250)
         except:
-            os.system('beep -f %s -l %s' % (323,250))
-            os.system('beep -f %s -l %s' % (583,250))
+            os.system('tput bel')
         cycles += 1
 
     reset()

--- a/pomodoro_timer/pomodoro_timer.py
+++ b/pomodoro_timer/pomodoro_timer.py
@@ -4,9 +4,14 @@ from tkinter import Button, Entry, Frame, Label, Tk
 from tkinter.constants import BOTTOM, FLAT, LEFT
 from tkinter.font import BOLD
 import threading
-import winsound
+import os
 
-ctypes.windll.shcore.SetProcessDpiAwareness(True)
+try:
+    import winsound
+    ctypes.windll.shcore.SetProcessDpiAwareness(True)
+except:
+    pass
+
 
 root = Tk()
 root.config(bg="Salmon")
@@ -68,8 +73,14 @@ def start_timer(options, cycle_limit=5):
             root.update_idletasks()
             time.sleep(1)
             temp_work -= 1
-        winsound.Beep(323, 250)
-        winsound.Beep(583, 250)
+        
+        try:
+            winsound.Beep(323, 250)
+            winsound.Beep(583, 250)
+        except:
+            os.system('beep -f %s -l %s' % (323,250))
+            os.system('beep -f %s -l %s' % (583,250))
+
         while temp_break:
             title_label.config(text="You should be taking a break now.")
             minutes, seconds = divmod(temp_break, 60)
@@ -77,8 +88,12 @@ def start_timer(options, cycle_limit=5):
             root.update_idletasks()
             time.sleep(1)
             temp_break -= 1
-        winsound.Beep(523, 250)
-        winsound.Beep(783, 250)
+        try:
+            winsound.Beep(523, 250)
+            winsound.Beep(783, 250)
+        except:
+            os.system('beep -f %s -l %s' % (323,250))
+            os.system('beep -f %s -l %s' % (583,250))
         cycles += 1
 
     reset()

--- a/pomodoro_timer/pomodoro_timer.py
+++ b/pomodoro_timer/pomodoro_timer.py
@@ -9,9 +9,8 @@ import os
 try:
     import winsound
     ctypes.windll.shcore.SetProcessDpiAwareness(True)
-except:
+except Exception:
     pass
-
 
 root = Tk()
 root.config(bg="Salmon")
@@ -73,11 +72,10 @@ def start_timer(options, cycle_limit=5):
             root.update_idletasks()
             time.sleep(1)
             temp_work -= 1
-        
         try:
             winsound.Beep(323, 250)
             winsound.Beep(583, 250)
-        except:
+        except Exception:
             os.system('tput bel')
 
         while temp_break:
@@ -90,7 +88,7 @@ def start_timer(options, cycle_limit=5):
         try:
             winsound.Beep(523, 250)
             winsound.Beep(783, 250)
-        except:
+        except Exception:
             os.system('tput bel')
         cycles += 1
 


### PR DESCRIPTION
**script name** - pomodoro_timer.py

**Fixing the pomodoro timer which was not working because of winsound**


### Issue no. - #894

### Self Check(Tick After Making pull Request)

- [ ] This issue was assigned to me.
- [x] One Change in one Pull Request
- [x] My file is in proper folder (Name of folder should be in lowercase with no space in between) (E.g. meet_schedular)
- [x] I am following clean code and Documentation and my code is well linted with flake8.
- [x] I have added README.md and requirements.txt (Include version numbers too e.g. pandas==0.0.1) with my script
- [x] I have used REPO **[README TEAMPLATE](https://github.com/python-geeks/Automation-scripts/blob/main/README_TEMPLATE.md)** (Necessary)
- [x] Just including required dependencies in requirements.txt (Don't include Python version too)

